### PR TITLE
fix(go): set the go directive to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/alexfalkowski/gocovmerge
 
-go 1.22.6
+go 1.22
 
 require golang.org/x/tools v0.23.0


### PR DESCRIPTION
Hi @alexfalkowski, thanks for your work maintaining this package :pray:

I'm an etcd contributor, and every time we have an from this dependency, it bumps our go directive to the latest Go patch. After we run our automation, we need to change the version (to remove the patch) manually.

The go directive from the `go.mod` file should be set to the minimum version required to compile packages from the module. This project's code should work fine with any version greater than 1.22. This avoids projects that depend on this package getting a go directive version bump every time there's a new version of this dependency.

The previous statement is explained in more detail in [Go's documentation](https://go.dev/doc/modules/gomod-ref#go).

It would be great if you could accept this pull request, as other projects that depend on this package are probably experiencing the same symptom. Because etcd is an open source project and it can be used as a dependency, too. We need to set the Go version to the minimum supported version, and there's no reason to lock it to the patch.

Thanks again!