### PR TITLE
build(ci): remove execinquery

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - errname
     - errorlint
     - exportloopref
-    - execinquery
     - exhaustive
     - exportloopref
     - forbidigo


### PR DESCRIPTION
WARN The linter 'execinquery' is deprecated (since v1.58.0) due to: The repository of the linter has been archived by the owner. 