### PR TITLE
fix(io): stage file output before replacing destination

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - depguard
     - funcorder
     - gochecknoglobals
+    - gomodguard_v2
     - ireturn
     - nilnil
     - nlreturn

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // Writer is the output sink used by the CLI.
@@ -52,15 +53,33 @@ func (o *fileOutput) Write(p []byte) (int, error) {
 }
 
 func (o *fileOutput) Close() error {
-	file, err := os.Create(o.path)
+	dir := filepath.Dir(o.path)
+	file, err := os.CreateTemp(dir, ".gocovmerge-*")
 	if err != nil {
 		return err
 	}
+
+	name := file.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(name)
+		}
+	}()
 
 	if _, err := o.buffer.WriteTo(file); err != nil {
 		_ = file.Close()
 		return err
 	}
 
-	return file.Close()
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(name, o.path); err != nil {
+		return err
+	}
+
+	committed = true
+	return nil
 }

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -1,0 +1,47 @@
+package io_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/alexfalkowski/gocovmerge/v2/internal/io"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileOutputReplacesDestinationOnlyOnClose(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cover.out")
+	require.NoError(t, os.WriteFile(path, []byte("previous\n"), 0o600))
+
+	out := io.Output(path, &bytes.Buffer{})
+	_, err := out.Write([]byte("mode: set\n"))
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "previous\n", string(got))
+
+	require.NoError(t, out.Close())
+
+	got, err = os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "mode: set\n", string(got))
+}
+
+func TestFileOutputRemovesTempFileWhenCommitFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, strings.Repeat("a", 300))
+
+	out := io.Output(path, &bytes.Buffer{})
+	_, err := out.Write([]byte("mode: set\n"))
+	require.NoError(t, err)
+
+	require.Error(t, out.Close())
+
+	matches, err := filepath.Glob(filepath.Join(dir, ".gocovmerge-*"))
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}


### PR DESCRIPTION
## What
- Stage file-backed coverage output in a same-directory temp file before replacing the destination.
- Remove staged temp files when commit to the destination fails.
- Add coverage for delayed replacement and temp cleanup behavior.

## Why
- Prevent an existing -o output file from being truncated or left partial when final file writes fail after a successful merge.

## Testing
- go test -mod=vendor ./...
- make lint
- make specs
