### PR TITLE
feat(path): cover merge edge cases

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  precision: 2
+  round: down
+  range: "80...100"
+  status:
+    patch: off

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 *.cov
 *.xml
 *.html
+.source-key
+ISSUES.md

--- a/internal/cover/cover_test.go
+++ b/internal/cover/cover_test.go
@@ -33,6 +33,16 @@ func TestAddProfileRejectsUnsupportedMode(t *testing.T) {
 	require.ErrorIs(t, err, cover.ErrUnsupportedMode)
 }
 
+func TestAddProfileKeepsProfilesSortedByFileName(t *testing.T) {
+	profiles := []*cover.Profile{
+		test.Profile("b.go", "set", test.Block(1, 1, 1, 2, 1)),
+	}
+
+	merged, err := cover.AddProfile(profiles, test.Profile("a.go", "set", test.Block(1, 1, 1, 2, 1)))
+	require.NoError(t, err)
+	require.Equal(t, []string{"a.go", "b.go"}, []string{merged[0].FileName, merged[1].FileName})
+}
+
 func TestAddProfileAppendsTrailingBlocks(t *testing.T) {
 	profiles := []*cover.Profile{
 		test.Profile("a.go", "set", test.Block(1, 1, 1, 2, 1)),
@@ -54,4 +64,13 @@ func TestAddProfileRejectsOverlapAfter(t *testing.T) {
 
 	_, err := cover.AddProfile(profiles, test.Profile("a.go", "set", test.Block(1, 4, 2, 2, 1)))
 	require.ErrorContains(t, err, "overlap after")
+}
+
+func TestAddProfileRejectsSameStartDifferentEnd(t *testing.T) {
+	profiles := []*cover.Profile{
+		test.Profile("a.go", "set", test.Block(1, 1, 1, 5, 1)),
+	}
+
+	_, err := cover.AddProfile(profiles, test.Profile("a.go", "set", test.Block(1, 1, 1, 10, 1)))
+	require.ErrorContains(t, err, "overlap merge")
 }

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -2,6 +2,7 @@ package path
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"regexp"
 )
@@ -59,7 +60,31 @@ func abs(path string) (string, error) {
 	if len(path) == 0 {
 		return "", nil
 	}
-	return filepath.Abs(path)
+
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		return filepath.Join(canonicalDir(absolute), filepath.Base(absolute)), nil
+	}
+
+	return canonical, nil
+}
+
+func canonicalDir(path string) string {
+	dir, err := filepath.EvalSymlinks(filepath.Dir(path))
+	if err != nil {
+		return filepath.Dir(path)
+	}
+
+	return dir
 }
 
 func regex(pattern string) (*regexp.Regexp, error) {

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -1,0 +1,70 @@
+package path_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alexfalkowski/gocovmerge/v2/internal/path"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesFiltersNestedFilesByWalkedPath(t *testing.T) {
+	dir := t.TempDir()
+	selected := writeTextFile(t, filepath.Join(dir, "nested", "selected.cov"))
+	writeTextFile(t, filepath.Join(dir, "ignored.cov"))
+
+	files, err := path.Files(dir, `nested[/\\].*\.cov$`, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{selected}, files)
+}
+
+func TestFilesExcludesRelativeOutputAcrossSymlinkedPaths(t *testing.T) {
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	linkDir := filepath.Join(base, "link")
+	require.NoError(t, os.Mkdir(realDir, 0o755))
+	require.NoError(t, os.Symlink(realDir, linkDir))
+
+	input := writeTextFile(t, filepath.Join(realDir, "a.out"))
+	writeTextFile(t, filepath.Join(realDir, "merged.out"))
+
+	t.Chdir(linkDir)
+
+	files, err := path.Files(realDir, "", "merged.out")
+	require.NoError(t, err)
+	require.Equal(t, []string{input}, files)
+}
+
+func TestFilesAcceptsExcludedPathWithMissingParent(t *testing.T) {
+	input := writeTextFile(t, filepath.Join(t.TempDir(), "a.out"))
+
+	files, err := path.Files(filepath.Dir(input), "", filepath.Join(filepath.Dir(input), "missing", "cover.out"))
+	require.NoError(t, err)
+	require.Equal(t, []string{input}, files)
+}
+
+func TestFilesReportsExcludedPathSymlinkLoop(t *testing.T) {
+	dir := t.TempDir()
+	loop := filepath.Join(dir, "loop")
+	require.NoError(t, os.Symlink(loop, loop))
+
+	files, err := path.Files(dir, "", loop)
+	require.Error(t, err)
+	require.Nil(t, files)
+}
+
+func TestFilesReportsInvalidPattern(t *testing.T) {
+	files, err := path.Files(t.TempDir(), "[", "")
+	require.Error(t, err)
+	require.Nil(t, files)
+}
+
+func writeTextFile(t *testing.T, path string) string {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("mode: set\n"), 0o600))
+
+	return path
+}

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,8 @@ import (
 
 var errWriteFailed = errors.New("write failed")
 
+const failedParseProfiles = "failed to parse profiles"
+
 func TestRunScenarios(t *testing.T) {
 	for _, tt := range runScenarioCases {
 		t.Run(tt.Name, func(t *testing.T) {
@@ -29,7 +31,7 @@ func TestMainEntrypoint(t *testing.T) {
 	t.Helper()
 
 	if os.Getenv("GO_WANT_MAIN") == "1" {
-		os.Args = []string{"gocovmerge", os.Getenv("GO_WANT_MAIN_PROFILE")}
+		os.Args = []string{"gocovmerge", os.Getenv("GO_WANT_MAIN_ARG")}
 		main()
 		return
 	}
@@ -45,10 +47,52 @@ func TestMainEntrypoint(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
+	cases := []struct {
+		name               string
+		arg                string
+		wantStdout         string
+		wantStderrContains []string
+		wantExit           int
+	}{
+		{
+			name:       "success",
+			arg:        profilePath,
+			wantExit:   0,
+			wantStdout: test.TextProfile("set", test.TextBlock("foo.go", 1, 1, 1, 2, 1, 1)),
+		},
+		{
+			name:     "failure",
+			arg:      filepath.Join(dir, "missing.out"),
+			wantExit: 1,
+			wantStderrContains: []string{
+				failedParseProfiles,
+				"missing.out",
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr := executeMainEntrypoint(t, ctx, executable, tt.arg, tt.wantExit)
+
+			require.Equal(t, tt.wantStdout, stdout.String())
+			for _, want := range tt.wantStderrContains {
+				require.Contains(t, stderr.String(), want)
+			}
+			if len(tt.wantStderrContains) == 0 {
+				require.Empty(t, stderr.String())
+			}
+		})
+	}
+}
+
+func executeMainEntrypoint(t *testing.T, ctx context.Context, executable, arg string, wantExit int) (bytes.Buffer, bytes.Buffer) {
+	t.Helper()
+
 	cmd := exec.CommandContext(ctx, executable, "-test.run=^TestMainEntrypoint$")
 	cmd.Env = append(os.Environ(),
 		"GO_WANT_MAIN=1",
-		"GO_WANT_MAIN_PROFILE="+profilePath,
+		"GO_WANT_MAIN_ARG="+arg,
 	)
 
 	var stdout bytes.Buffer
@@ -56,12 +100,16 @@ func TestMainEntrypoint(t *testing.T) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err = cmd.Run()
-	require.NoErrorf(t, err, "expected main to succeed with stderr %q", stderr.String())
+	err := cmd.Run()
+	if wantExit == 0 {
+		require.NoErrorf(t, err, "expected main to succeed with stderr %q", stderr.String())
+	} else {
+		var exitError *exec.ExitError
+		require.ErrorAs(t, err, &exitError)
+		require.Equal(t, wantExit, exitError.ExitCode())
+	}
 
-	want := test.TextProfile("set", test.TextBlock("foo.go", 1, 1, 1, 2, 1, 1))
-	require.Equal(t, want, stdout.String())
-	require.Empty(t, stderr.String())
+	return stdout, stderr
 }
 
 var runScenarioCases = []test.RunScenario{
@@ -115,7 +163,7 @@ var runScenarioCases = []test.RunScenario{
 		WantStdout:      "",
 		WantStderrEmpty: false,
 		WantStderrContains: []string{
-			"failed to parse profiles",
+			failedParseProfiles,
 			"missing.out",
 		},
 	},
@@ -196,6 +244,24 @@ var runScenarioCases = []test.RunScenario{
 		WantStderrEmpty: true,
 	},
 	{
+		Name: "atomic mode merges counts by addition",
+		Setup: func(t *testing.T, dir string) []string {
+			t.Helper()
+
+			first := test.WriteProfileFile(t, dir, "a.out", test.TextProfile("atomic",
+				test.TextBlock("foo.go", 1, 1, 1, 2, 1, 1),
+			))
+			second := test.WriteProfileFile(t, dir, "b.out", test.TextProfile("atomic",
+				test.TextBlock("foo.go", 1, 1, 1, 2, 1, 2),
+			))
+
+			return []string{first, second}
+		},
+		WantExit:        0,
+		WantStdout:      test.TextProfile("atomic", test.TextBlock("foo.go", 1, 1, 1, 2, 1, 3)),
+		WantStderrEmpty: true,
+	},
+	{
 		Name: "non overlapping blocks are inserted in order",
 		Setup: func(t *testing.T, dir string) []string {
 			t.Helper()
@@ -238,6 +304,39 @@ var runScenarioCases = []test.RunScenario{
 			test.TextBlock("a.go", 1, 1, 1, 2, 1, 1),
 			test.TextBlock("b.go", 2, 1, 2, 2, 1, 1),
 		),
+		WantStderrEmpty: true,
+	},
+	{
+		Name: "directory input filters nested files by walked path",
+		Setup: func(t *testing.T, dir string) []string {
+			t.Helper()
+
+			test.WriteProfileFile(t, filepath.Join(dir, "nested"), "selected.cov", test.TextProfile("set",
+				test.TextBlock("nested.go", 1, 1, 1, 2, 1, 1),
+			))
+			test.WriteProfileFile(t, dir, "ignored.cov", test.TextProfile("set",
+				test.TextBlock("ignored.go", 2, 1, 2, 2, 1, 1),
+			))
+
+			return []string{"-d", dir, "-p", `nested[/\\].*\.cov$`}
+		},
+		WantExit:        0,
+		WantStdout:      test.TextProfile("set", test.TextBlock("nested.go", 1, 1, 1, 2, 1, 1)),
+		WantStderrEmpty: true,
+	},
+	{
+		Name: "directory input ignores positional args",
+		Setup: func(t *testing.T, dir string) []string {
+			t.Helper()
+
+			test.WriteProfileFile(t, dir, "a.out", test.TextProfile("set",
+				test.TextBlock("dir.go", 1, 1, 1, 2, 1, 1),
+			))
+
+			return []string{"-d", dir, filepath.Join(dir, "missing.out")}
+		},
+		WantExit:        0,
+		WantStdout:      test.TextProfile("set", test.TextBlock("dir.go", 1, 1, 1, 2, 1, 1)),
 		WantStderrEmpty: true,
 	},
 	{
@@ -349,7 +448,7 @@ var fileOutputScenarioCases = []test.FileOutputScenario{
 		WantExit:        1,
 		WantStderrEmpty: false,
 		WantStderrContains: []string{
-			"failed to parse profiles",
+			failedParseProfiles,
 		},
 		Check: func(t *testing.T, dir, stdout, _ string) {
 			t.Helper()
@@ -455,6 +554,28 @@ func TestRunDirectoryInputExcludesExistingOutputFile(t *testing.T) {
 	}
 
 	got, err := os.ReadFile(output)
+	require.NoError(t, err)
+
+	want, err := os.ReadFile(input)
+	require.NoError(t, err)
+	require.Equal(t, string(want), string(got))
+}
+
+func TestRunDirectoryInputExcludesRelativeOutputFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	input := test.WriteProfileFile(t, dir, "a.out", test.TextProfile("count",
+		test.TextBlock("foo.go", 1, 1, 1, 2, 1, 1),
+	))
+
+	for i := range 2 {
+		exitCode, stdout, stderr := test.ExecuteRun(t, run, []string{"-d", dir, "-o", "merged.out"}, nil)
+		require.Equalf(t, 0, exitCode, "run %d stderr: %q", i+1, stderr)
+		require.Emptyf(t, stdout, "run %d expected file output to keep stdout empty", i+1)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "merged.out"))
 	require.NoError(t, err)
 
 	want, err := os.ReadFile(input)


### PR DESCRIPTION
## What

- Add CLI coverage for main failure exits, atomic merge success, directory path filtering, directory precedence, and relative output exclusion.
- Add cover package tests for profile filename ordering and same-start different-end block rejection.
- Canonicalize discovered and excluded paths so relative output exclusion works across symlinked path spellings.
- Ignore generated source keys and the temporary test-gap ledger.

## Why

- Protect documented merge and directory-discovery behavior from regressions.
- Prevent reruns with relative output paths from merging the previous output back into the result.

## Testing

- `make lint` - passed
- `make specs` - passed
- `go test -mod=vendor ./...` - passed
