### PR TITLE
docs(readme): clarify coverage merge workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Tests currently live in:
 
 - `main_test.go`
 - `internal/cover/cover_test.go`
+- `internal/io/io_test.go`
+- `internal/path/path_test.go`
 - `internal/test`: shared test helpers and scenario scaffolding used by the test suites above.
 
 ## CI
@@ -57,6 +59,7 @@ The main build job runs:
 - `make specs`
 - `make build`
 - `make coverage`
+- `make codecov-upload`
 
 Artifacts and test results are stored from `test/reports`.
 
@@ -74,5 +77,5 @@ Artifacts and test results are stored from `test/reports`.
 ## Conventions
 
 - Prefer wrapped errors with context via `fmt.Errorf("...: %w", err)`.
-- Sentinel errors in `internal/cover`: `ErrInvalidMode`, `ErrEmptyProfiles`.
+- Sentinel errors in `internal/cover`: `ErrInvalidMode`, `ErrUnsupportedMode`, `ErrEmptyProfiles`.
 - Go files and Makefiles use tabs (`.editorconfig`).

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 
-# Build release binary.
+# Build race-enabled binary.
 build:
 	@go build -race -mod vendor -o gocovmerge

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ gocovmerge -d ./coverage -p '.*\.cov$' > cover.out
 
 - If `-o` is provided, output is written to that file.
 - If `-o` is provided, the merged profile is buffered first and the destination file is only created/truncated after a successful merge.
+- The parent directory for `-o` must already exist.
 - If `-o` is not provided, output is written to stdout.
 - With explicit positional arguments, `-o` may point at one of the input files because the input is read before the final output file is written.
 

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -43,11 +43,12 @@ func ParseProfiles(fileName string) ([]*Profile, error) {
 // AddProfile inserts p into profiles, merging it with an existing profile for
 // the same filename if present.
 //
-// profiles is kept sorted by Profile.FileName. If a profile with the same
-// FileName already exists, blocks from p are merged into it. All profiles in
-// the slice must use the same coverage mode. Blocks with the same coordinates
-// must also agree on NumStmt; otherwise AddProfile returns an error. Overlapping
-// or otherwise incompatible blocks are rejected.
+// profiles must already be sorted by Profile.FileName and contain one coverage
+// mode, typically because it was produced by prior AddProfile calls. The returned
+// slice is kept sorted by Profile.FileName. If a profile with the same FileName
+// already exists, blocks from p are merged into it. Blocks with the same
+// coordinates must also agree on NumStmt; otherwise AddProfile returns an error.
+// Overlapping or otherwise incompatible blocks are rejected.
 func AddProfile(profiles []*Profile, p *Profile) ([]*Profile, error) {
 	if err := validateMode(p.Mode); err != nil {
 		return nil, err

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -18,9 +18,10 @@ var ErrHelp = flag.ErrHelp
 //   - `-d`: directory containing coverage profiles (if empty, positional args are used)
 //   - `-p`: regexp pattern to filter files when `-d` is set (if empty, all files are included)
 //
-// Any remaining positional arguments after flags are treated as coverage
-// profile paths. Flag usage and parse errors are written to output when it is
-// non-nil.
+// Any remaining positional arguments after flags are treated as coverage profile
+// paths. When output is non-nil, flag usage and parse errors are written there.
+// When output is nil, the flag package's default stderr output is used; pass
+// io.Discard to suppress flag output.
 func Parse(args []string, output io.Writer) (*Values, error) {
 	set := flag.NewFlagSet("gocovmerge", flag.ContinueOnError)
 	if output != nil {

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -12,8 +12,10 @@ import (
 // If pattern is non-empty it is treated as a regular expression and matched
 // against the walked path. If pattern is empty, all files are returned. If
 // exclude is non-empty, that path is skipped from the returned results. The
-// exclusion check compares absolute paths so relative `-o` values are handled
-// consistently.
+// exclusion check canonicalizes walked paths and exclude with symlink
+// evaluation so relative `-o` values are handled consistently. Missing excluded
+// paths are resolved through their canonical parent, but other canonicalization
+// errors are returned.
 func Files(dir, pattern, exclude string) ([]string, error) {
 	re, err := regex(pattern)
 	if err != nil {

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -95,7 +95,9 @@ func RunFileOutputScenarioCase(t *testing.T, run RunFunc, tt FileOutputScenario)
 	}
 }
 
-// ExecuteRun executes run with in-memory stdout and stderr buffers.
+// ExecuteRun executes run with an in-memory stderr buffer. If stdoutWriter is
+// nil, stdout is captured in memory and returned. Otherwise stdout is written to
+// stdoutWriter and the returned stdout string is empty.
 func ExecuteRun(t *testing.T, run RunFunc, args []string, stdoutWriter io.Writer) (int, string, string) {
 	t.Helper()
 


### PR DESCRIPTION
## What

- Clarify CLI output behavior by documenting that `-o` requires an existing parent directory.
- Update repository guidance so the test inventory, CI build sequence, and `internal/cover` sentinel-error list match the current codebase.
- Tighten GoDoc for merge invariants, flag parser output behavior, path exclusion canonicalization, and test helper stdout capture.

## Why

- These updates remove stale or incomplete guidance that could mislead users running file output and maintainers changing merge, path, flag, or test helper behavior.
- Keeping repository instructions aligned with the actual test and CI surfaces makes future validation and review work less error-prone.

## Testing

- `git diff --check` - passed
- `make lint` - passed
- `go test -mod=vendor ./...` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
