### PR TITLE
docs(readme): clarify coverage merge contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 include bin/build/make/go.mak
 include bin/build/make/git.mak
+include bin/build/make/help.mak
 
 # Build race-enabled binary.
 build:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage of gocovmerge:
   -o string
         output file (if missing stdout)
   -p string
-        pattern to filter directory (if missing all files)
+        regexp pattern to filter directory (if missing all files)
 ```
 
 `-help` prints usage and exits with status `0`. Parse errors and runtime errors
@@ -152,6 +152,17 @@ If profiles refer to different versions of the same file, block boundaries may d
 > [!IMPORTANT]
 > Merge only profiles produced from the same checkout or commit. Coverage block positions are source-dependent, so profiles from different revisions can be incompatible even when file names match.
 
+### 🧾 Profile filenames must match exactly
+
+Profiles are grouped by the exact `Profile.FileName` string from each coverage
+profile. `gocovmerge` does not normalize, relativize, or otherwise reconcile
+filenames.
+
+If different shards write the same source file with different path spellings
+(for example absolute paths in one profile and relative paths in another), those
+entries are kept separate instead of being merged, and the command can still
+succeed.
+
 ### 🎛️ Coverage modes must match
 
 Profiles must use the same coverage mode (`set`, `count`, or `atomic`) across
@@ -183,7 +194,7 @@ excluding `-o`), there are no profiles to write and the command fails.
 ## 📝 Notes
 
 - The merged output is a standard Go coverage profile: a single `mode: ...` header line followed by block lines.
-- Merging is performed per `Profile.FileName`; within a file:
+- Merging is performed per exact `Profile.FileName` string; within a file:
   - `set` mode merges counts using bitwise OR.
   - `count` and `atomic` modes merge counts by summing.
   - same-position blocks must also agree on `NumStmt`.

--- a/internal/cover/cover.go
+++ b/internal/cover/cover.go
@@ -44,11 +44,16 @@ func ParseProfiles(fileName string) ([]*Profile, error) {
 // the same filename if present.
 //
 // profiles must already be sorted by Profile.FileName and contain one coverage
-// mode, typically because it was produced by prior AddProfile calls. The returned
-// slice is kept sorted by Profile.FileName. If a profile with the same FileName
-// already exists, blocks from p are merged into it. Blocks with the same
-// coordinates must also agree on NumStmt; otherwise AddProfile returns an error.
-// Overlapping or otherwise incompatible blocks are rejected.
+// mode, typically because it was produced by prior AddProfile calls. Existing
+// blocks and p.Blocks must also be sorted by block start position, typically by
+// ParseProfiles. The returned slice is kept sorted by Profile.FileName.
+//
+// AddProfile mutates existing profiles when merging counts and inserts p
+// directly when adding a new filename; it does not deep-copy profile data. If a
+// profile with the same FileName already exists, blocks from p are merged into
+// it. Blocks with the same coordinates must also agree on NumStmt; otherwise
+// AddProfile returns an error. Overlapping or otherwise incompatible blocks are
+// rejected.
 func AddProfile(profiles []*Profile, p *Profile) ([]*Profile, error) {
 	if err := validateMode(p.Mode); err != nil {
 		return nil, err

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -18,10 +18,11 @@ var ErrHelp = flag.ErrHelp
 //   - `-d`: directory containing coverage profiles (if empty, positional args are used)
 //   - `-p`: regexp pattern to filter files when `-d` is set (if empty, all files are included)
 //
-// Any remaining positional arguments after flags are treated as coverage profile
-// paths. When output is non-nil, flag usage and parse errors are written there.
-// When output is nil, the flag package's default stderr output is used; pass
-// io.Discard to suppress flag output.
+// Any remaining positional arguments after flags are retained for explicit-file
+// mode; Values.Files ignores them when `-d` is set. When output is non-nil,
+// flag usage and parse errors are written there. When output is nil, the flag
+// package's default stderr output is used; pass io.Discard to suppress flag
+// output.
 func Parse(args []string, output io.Writer) (*Values, error) {
 	set := flag.NewFlagSet("gocovmerge", flag.ContinueOnError)
 	if output != nil {
@@ -30,7 +31,7 @@ func Parse(args []string, output io.Writer) (*Values, error) {
 
 	out := set.String("o", "", "output file (if missing stdout)")
 	dir := set.String("d", "", "directory of files (if missing paths passed in)")
-	pattern := set.String("p", "", "pattern to filter directory (if missing all files)")
+	pattern := set.String("p", "", "regexp pattern to filter directory (if missing all files)")
 
 	if err := set.Parse(args); err != nil {
 		return nil, err

--- a/internal/test/cli.go
+++ b/internal/test/cli.go
@@ -36,6 +36,9 @@ type RunScenario struct {
 
 // FileOutputScenario describes one CLI test case that writes merged output to a
 // file via `-o`.
+//
+// Setup is required and must return the complete CLI argument list for the
+// scenario.
 type FileOutputScenario struct {
 	Name               string
 	Setup              func(t *testing.T, dir string) []string


### PR DESCRIPTION
## What

- Clarify that directory filters use Go regular expressions in both CLI help and the usage example.
- Document that coverage profile filenames are matched exactly and are not normalized before merging.
- Add maintainer-facing GoDoc for merge preconditions, mutation behavior, flag precedence, and file-output test scenario setup.
- Include the shared help make fragment so `make help` exposes the repository command catalog.

## Why

- Users can otherwise mistake `-p` for a glob or assume coverage entries with different path spellings are reconciled automatically.
- Maintainers need the non-obvious merge and helper contracts near the exported surfaces they preserve.
- The command catalog should be available through the standard shared Makefile help target.

## Testing

- `make specs` - passed
- `make lint` - passed
- `make build` - passed
- `make help` - passed
