### PR TITLE
docs(agents): prefer make command surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
-This repository is a small Go CLI tool (`gocovmerge`) that merges multiple Go coverage profiles (from `go test -coverprofile`) into a single profile.
+This repository is a small Go CLI tool (`gocovmerge`) that merges multiple Go
+coverage profiles into a single profile.
 
 ## Shared guidance
 
@@ -19,19 +20,18 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 
 ## Tooling
 
-- Go version: `go 1.26.0`.
+- Go toolchain details live in `go.mod`.
 - The repo uses vendoring (`-mod vendor`).
 - If the `bin/` submodule is missing, `make` targets will fail.
 
 Useful commands:
 
-- `make dep`: `go mod download`, `go mod tidy`, `go mod vendor`
+- `make dep`: refresh dependencies and vendor state
 - `make build`: build `gocovmerge`
-- `make lint`: field alignment + `golangci-lint`
-- `make sec`: `govulncheck -show verbose -test ./...`
-- `make specs`: race-enabled test run with coverage via `gotestsum`
+- `make lint`: run repository linting
+- `make sec`: run repository security checks
+- `make specs`: run the repository test target
 - `make coverage`: post-process `test/reports/profile.cov`
-- `go test -mod=vendor ./...`: quick local test run
 
 Tests currently live in:
 
@@ -45,9 +45,8 @@ Tests currently live in:
 
 CircleCI config: `.circleci/config.yml`.
 
-The main build job runs:
+The main build job initializes submodules, then runs:
 
-- `git submodule sync` / `git submodule update --init`
 - `make source-key`
 - `make clean`
 - `make dep`


### PR DESCRIPTION
## What

- Update the `bin` submodule to the shared guidance that centralizes Makefile-first command policy.
- Clean up local `AGENTS.md` guidance so repository instructions prefer Make targets instead of direct tool commands.
- Remove stale-prone runtime, toolchain, dependency, or image version claims from local agent guidance where they belonged in source files or CI configuration.

## Why

- Keeps command guidance aligned with the shared `bin/AGENTS.md` policy and avoids copying ad hoc commands across repositories.
- Reduces stale local agent instructions by leaving changing versions and tool details in their authoritative files.

## Testing

- `git diff --check` - passed
- `zsh -lic 'make lint'` - passed
- Direct-command guidance scan - passed
- Exact-version guidance scan - passed; remaining matches are IP address literals, not dependency, toolchain, or image versions.

AI-assisted-by: [Codex](https://openai.com/codex/)
