### PR TITLE
build(project): show help by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
+include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
-include bin/build/make/help.mak
 
 # Build race-enabled binary.
 build:


### PR DESCRIPTION
## What

- Move the shared help make fragment before the Go and Git fragments in the root Makefile.
- Keep all explicit targets unchanged.

## Why

- Bare GNU Make previously selected the first `go.mak` target and tried to download modules.
- Making help the default keeps command discovery side-effect free and matches the rest of the shared-bin repositories.

## Testing

- `gmake -n` - passed and dry-runs the shared help target.
- `gmake help` - passed.
