### PR TITLE
build(ci): reuse dependency cache across source changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ jobs:
       - restore_cache:
           name: restore deps
           keys:
-            - gocovmerge-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+            - gocovmerge-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
             - gocovmerge-go-cache-
       - run: make clean
       - run: make dep
       - save_cache:
           name: save deps
-          key: gocovmerge-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}
+          key: gocovmerge-go-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}
           paths:
             - ~/go/pkg/mod
       - restore_cache:


### PR DESCRIPTION
## What

- Remove the `.source-key` checksum suffix from CircleCI dependency cache restore and save keys.
- Keep source-keyed Go build and lint caches unchanged.

## Why

- Dependency caches should be reused across source-only changes instead of being invalidated for every repository source update.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'` - passed
- `git diff --check -- .circleci/config.yml` - passed
- Targeted scan across dependency cache blocks verified no remaining `.source-key` checksum suffixes.
