### PR TITLE
build(deps): update bin to adopt the shared claude permissions baseline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,1 @@
+../bin/build/claude/settings.json


### PR DESCRIPTION
## What

- Bump the `bin` submodule to `origin/master`, adopting the shared Claude Code
  permissions baseline (#532) along with the intervening shared-tooling updates
  already merged on `bin` master (docs, and where applicable the golang Docker
  base-image bump).
- Commit the `.claude/settings.json` symlink to `bin/build/claude/settings.json`
  created by `make claude-init`, alongside the existing `.claude/skills` symlink.

## Why

- Adopt the shared permissions baseline so Claude Code sessions in this
  repository inherit the same guardrailed, low-friction autonomy maintained
  centrally in `bin`, and keep this repository's shared `bin` tooling current.

## Testing

- `make claude-init` - passed; `.claude/settings.json -> ../bin/build/claude/settings.json` resolves and reads `defaultMode=acceptEdits` (allow 122 / ask 42 / deny 23)
- Change set in this repository is the `bin` submodule pointer plus the `.claude/settings.json` symlink; no repository source changed
- CircleCI on this PR provides full validation of the bumped shared tooling

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
