### PR TITLE
test(feature): cover walked-path canonicalization errors during -o exclusion

### DIFF
--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -54,6 +54,16 @@ func TestFilesReportsExcludedPathSymlinkLoop(t *testing.T) {
 	require.Nil(t, files)
 }
 
+func TestFilesReportsWalkedPathSymlinkLoop(t *testing.T) {
+	dir := t.TempDir()
+	loop := filepath.Join(dir, "loop")
+	require.NoError(t, os.Symlink(loop, loop))
+
+	files, err := path.Files(dir, "", filepath.Join(dir, "merged.out"))
+	require.Error(t, err)
+	require.Nil(t, files)
+}
+
 func TestFilesReportsInvalidPattern(t *testing.T) {
 	files, err := path.Files(t.TempDir(), "[", "")
 	require.Error(t, err)


### PR DESCRIPTION
## What

- Added a unit test for `path.Files` that exercises the walked-path canonicalization error branch: the fail-closed behavior when a file discovered while walking the scanned directory can't be canonicalized, while the `-o` exclude path is valid.
- Test-only change; `internal/path/path.go` behavior is unchanged.

## Why

- The walked-path `abs` error branch (`path.go:41-44`) is one half of an intentionally paired fail-closed design; only the exclude-argument side was previously covered, by `TestFilesReportsExcludedPathSymlinkLoop`.
- Left unprotected, a future change that swallowed this error instead of returning it could silently drop coverage files during a directory-mode merge with `-o`, producing an incomplete merged profile with no test failing to catch it.

## Testing

- `make specs` - passed (44 tests, including the new `TestFilesReportsWalkedPathSymlinkLoop`)
- `make lint` - passed (0 issues)
- `make sec` - passed (no vulnerabilities, no secrets)
- `make build` - passed
- The new test places a self-referential symlink inside the walked directory alongside a valid, distinct exclude path, and asserts `path.Files` returns an error and a nil file list. Confirmed it isn't vacuous with a temporary mutation (swallowing the walked-path error), which turned it red; reverted before committing.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
